### PR TITLE
Compatibility fix: Update Ruby 3 keyword arguments delegations

### DIFF
--- a/lib/crefo/service.rb
+++ b/lib/crefo/service.rb
@@ -12,7 +12,7 @@ module Crefo
     def process
       begin
         url = Crefo.config.endpoint
-        request = self.class::Request.new(options)
+        request = self.class::Request.new(**options)
         response_data = request.send(url)
         response = self.class::Response.new(response_data)
       rescue Crefo::Service::Response::ResponseError => exception


### PR DESCRIPTION
# Description

The following exception is raised when trying to create a new report in Ruby 3.

```ruby
ArgumentError:
  wrong number of arguments (given 1, expected 0)
# .../bundler/gems/crefo-b950bca2ae6e/lib/crefo/service/request.rb:8:in `initialize'
# .../bundler/gems/crefo-b950bca2ae6e/lib/crefo/service.rb:15:in `new'
# .../bundler/gems/crefo-b950bca2ae6e/lib/crefo/service.rb:15:in `process'
```